### PR TITLE
Makefile: Use LDFLAGS if set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,17 +11,17 @@ all: groot libgroot.so
 
 groot: groot.c grootfs.c grootfs.h groot-ns.c groot-ns.h utils.h utils.c
 	$(CC) groot.c grootfs.c groot-ns.c utils.c \
-		$(CFLAGS) $(CPPFLAGS) $(GROOT_CFLAGS) $(FUSE_FLAGS) \
+		$(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $(GROOT_CFLAGS) $(FUSE_FLAGS) \
 		-o groot
 
 libgroot.so: groot-preload.c grootfs.c grootfs.h groot-ns.c groot-ns.h utils.h utils.c
 	$(CC) groot-preload.c grootfs.c  groot-ns.c utils.c \
-		$(CFLAGS) $(CPPFLAGS) $(GROOT_CFLAGS)  $(FUSE_FLAGS) \
+		$(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $(GROOT_CFLAGS)  $(FUSE_FLAGS) \
 		-fvisibility=hidden -Bsymbolic-functions -Bgroup -fPIC -shared -o libgroot.so
 
 fuse-grootfs: fuse-grootfs.c grootfs.c grootfs.h utils.h utils.c
 	$(CC) fuse-grootfs.c grootfs.c utils.c \
-		$(CFLAGS) $(CPPFLAGS) $(GROOT_CFLAGS) $(FUSE_FLAGS) \
+		$(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $(GROOT_CFLAGS) $(FUSE_FLAGS) \
 		-o fuse-grootfs
 
 install: groot libgroot.so


### PR DESCRIPTION
Yocto sets this for e.g. -L and rpath and we want to pick it up.